### PR TITLE
Add new Python scripts for chat history management

### DIFF
--- a/gerenciamento-de-historico/armazenamento-de-historico.py
+++ b/gerenciamento-de-historico/armazenamento-de-historico.py
@@ -1,0 +1,46 @@
+from dotenv import load_dotenv
+from langchain_openai import ChatOpenAI
+from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
+from langchain_core.chat_history import InMemoryChatMessageHistory
+from langchain_core.runnables import RunnableWithMessageHistory
+
+load_dotenv()
+
+prompt = ChatPromptTemplate.from_messages([
+    ("system", "You are a helpful assistant."),
+    MessagesPlaceholder(variable_name="history"),
+    ("human", "{input}"),
+])
+
+chat_model = ChatOpenAI(model="gpt-5-nano", temperature=0.9)
+
+chain = prompt | chat_model
+
+session_store: dict[str, InMemoryChatMessageHistory] = {}
+
+def get_session_history(session_id: str) -> InMemoryChatMessageHistory:
+    if session_id not in session_store:
+        session_store[session_id] = InMemoryChatMessageHistory()
+    return session_store[session_id]
+
+conversational_chain = RunnableWithMessageHistory(
+    chain,
+    get_session_history,
+    input_messages_key="input",
+    history_messages_key="history"
+)
+
+config = {"configurable": {"session_id": "demo-session"}}
+
+# Interageindo
+response1 = conversational_chain.invoke({"input": "Hello my name is Rodrigo, how are you?"}, config=config)
+print("Assistant: ", response1.content)
+print("-" * 30)
+
+response2 = conversational_chain.invoke({"input": "Can you repeat my name?"}, config=config)
+print("Assistant: ", response2.content)
+print("-" * 30)
+
+response3 = conversational_chain.invoke({"input": "Can you repeat mey name in a motivation phrase?"}, config=config)
+print("Assistant: ", response3.content)
+print("-" * 30)

--- a/gerenciamento-de-historico/historico-baseado-em-sliding-window.py
+++ b/gerenciamento-de-historico/historico-baseado-em-sliding-window.py
@@ -1,0 +1,59 @@
+from dotenv import load_dotenv
+from langchain_openai import ChatOpenAI
+from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
+from langchain_core.chat_history import InMemoryChatMessageHistory
+from langchain_core.runnables.history import RunnableWithMessageHistory
+from langchain_core.messages import trim_messages
+from langchain_core.runnables import RunnableLambda
+
+load_dotenv()
+
+prompt = ChatPromptTemplate.from_messages([
+    ("system", "You're a helpful assistant that answers with a short joke when possible."),
+    MessagesPlaceholder("history"),
+    ("human", "{input}"),
+])
+
+llm = ChatOpenAI(model="gpt-5-nano", temperature=0.9)
+
+def prepare_inputs(payload: dict) -> dict:
+    raw_history = payload.get("raw_history", [])
+    trimmed = trim_messages(
+        raw_history,
+        token_counter=len,
+        max_tokens=2,
+        strategy="last",
+        start_on="human",
+        include_system=True,
+        allow_partial=False,
+    )
+    return {"input": payload.get("input",""), "history": trimmed}
+
+prepare = RunnableLambda(prepare_inputs)
+chain = prepare | prompt | llm
+
+session_store: dict[str, InMemoryChatMessageHistory] = {}
+
+def get_session_history(session_id: str) -> InMemoryChatMessageHistory:
+    if session_id not in session_store:
+        session_store[session_id] = InMemoryChatMessageHistory()
+    return session_store[session_id]
+
+
+conversational_chain = RunnableWithMessageHistory(
+    chain,
+    get_session_history,
+    input_messages_key="input",
+    history_messages_key="raw_history"
+)
+
+config = {"configurable": {"session_id": "demo-session"}}
+
+resp1 = conversational_chain.invoke({"input": "My name is Rodrigo. Reply only with 'OK' and do not mention my name."}, config=config)
+print("Assistant:", resp1.content)
+
+resp2 = conversational_chain.invoke({"input": "Tell me a one-sentence fun fact. Do not mention my name."}, config=config)
+print("Assistant:", resp2.content)
+
+resp3 = conversational_chain.invoke({"input": "What is my name?"}, config=config)
+print("Assistant:", resp3.content)


### PR DESCRIPTION
- Introduced `armazenamento-de-historico.py` for managing chat sessions with a conversational chain using LangChain and OpenAI.
- Added `historico-baseado-em-sliding-window.py` to implement a sliding window approach for chat history, including input preparation and message trimming.
- Both scripts utilize environment variables and provide examples of interaction with the assistant.